### PR TITLE
fixed package declaration

### DIFF
--- a/src/main/groovy/cc/catalysts/gradle/plugins/teamcity/TeamcityPlugin.groovy
+++ b/src/main/groovy/cc/catalysts/gradle/plugins/teamcity/TeamcityPlugin.groovy
@@ -1,4 +1,4 @@
-package cc.catalysts.gradle.plugins.less
+package cc.catalysts.gradle.plugins.teamcity
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project


### PR DESCRIPTION
Teamcity plugin declared package cc.catalysts.gradle.plugins.less, but was located in teamcity package.
